### PR TITLE
More Notes

### DIFF
--- a/docs/01-infrastructure-azure.md
+++ b/docs/01-infrastructure-azure.md
@@ -650,16 +650,16 @@ info:    Executing command vm list
 + Getting virtual machines                                                     
 data:    ResourceGroupName  Name          ProvisioningState  PowerState  Location  Size       
 data:    -----------------  ------------  -----------------  ----------  --------  -----------
-data:    the-hard-way       controller-0  Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       controller-1  Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       controller-2  Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       etcd-0        Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       etcd-1        Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       etcd-2        Succeeded          VM running  westus    Standard_D4
+data:    the-hard-way       controller-0  Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       controller-1  Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       controller-2  Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       etcd-0        Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       etcd-1        Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       etcd-2        Succeeded          VM running  westus    Standard_A1
 data:    the-hard-way       jumpbox       Succeeded          VM running  westus    Standard_A1
-data:    the-hard-way       worker-0      Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       worker-1      Succeeded          VM running  westus    Standard_D4
-data:    the-hard-way       worker-2      Succeeded          VM running  westus    Standard_D4
+data:    the-hard-way       worker-0      Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       worker-1      Succeeded          VM running  westus    Standard_A1
+data:    the-hard-way       worker-2      Succeeded          VM running  westus    Standard_A1
 info:    vm list command OK
 ```
 
@@ -691,6 +691,7 @@ ssh -i ./cluster \
 	thehardway@10.240.0.31  
 
 #or
+
 ssh -i ./cluster \
 	thehardway@controller-1  
 

--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -139,7 +139,7 @@ KUBERNETES_PUBLIC_ADDRESS=$(aws elb describe-load-balancers \
 
 #### Azure
 
-this gets the address of the internal controllers load balancer
+This retrieves the address of the *internal* controllers load balancer.
 
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(azure network lb show \
@@ -257,7 +257,7 @@ done
 
 ### Azure
 
-If you are using the jumpbox to create the certificates
+If you were on the jumpbox create the certificates:
 
 ```
 for host in ${KUBERNETES_HOSTS[*]}; do
@@ -266,19 +266,16 @@ for host in ${KUBERNETES_HOSTS[*]}; do
 done
 ```
 
-If you used a different machine
+If you used a different machine:
 
 ```
-
 # Get jumpbox address
-
 KUBERNETES_JUMPBOX_ADDRESS=$(azure network public-ip show \
   --resource-group the-hard-way \
   --name the-hard-way-jumpbox \
   --json | jq -r '.dnsSettings.fqdn')
 
 # Copy files to jumpbox 
-
 scp -i ./keys/cluster \
   ca.pem \
   kubernetes-key.pem \

--- a/docs/09-smoke-test.md
+++ b/docs/09-smoke-test.md
@@ -83,28 +83,25 @@ NODE_PUBLIC_IP=$(aws ec2 describe-instances \
 
 ```
 # Get the fqdn for the public worker ingestion load balancer
-
 NODE_PUBLIC_IP=$(azure network public-ip show \
   --resource-group the-hard-way \
   --name the-hard-way-workers \
   --json | jq -r '.dnsSettings.fqdn')
 
 # Add NSG rule to enable traffic to workers' node ports
-
 azure network nsg rule create \
 	--resource-group the-hard-way \
 	--nsg-name the-hard-way-nsg \
 	--name allow-internet-$NODE_PORT \
 	--protocol tcp \
 	--access allow  \
-  --source-address-prefix Internet \
+	--source-address-prefix Internet \
 	--destination-address-prefix 10.240.0.0/16 \
 	--destination-port-range $NODE_PORT \
 	--priority 110 \
 	--direction inbound
 
 # Create load balancer rule NODE_PORT:NODE_PORT on the load balancer
-
 azure network lb probe create \
   --resource-group the-hard-way \
   --lb-name the-hard-way-lb \


### PR DESCRIPTION
~~\- Should we create availability set for etcd cluster?~~
- I couldn't get this to work. The command didn't prompt for password and it just failed outright.
  
  ```
  # Copy files from jumpbox to vms
  ssh -i ./keys/cluster \
  thehardway@$KUBERNETES_JUMPBOX_ADDRESS <<'EOF'
  
  KUBERNETES_HOSTS=(controller0 controller1 controller2 etcd0 etcd1 etcd2 worker0 worker1 worker2)
  for host in ${KUBERNETES_HOSTS[*]}; do
  scp -i ./cluster ca.pem kubernetes-key.pem kubernetes.pem \
    thehardway@${host}:~/
  done
  
  EOF
  ```
  
  AWS/GCE have similar instructions so maybe I misconfigured something along the way.
- Might be outside the scope of these changes, but we should add Windows instructions for downloading tools (cfssl, etc).
- Should we make the load balancers for controllers publicly accessible? This would remove the need for a jumpbox and have the infrastructure in-line with AWS/GCE instructions. We can add port mapping to ssh to specific machines.
- I love this! https://github.com/khenidak/kubernetes-the-hard-way/blob/azure/docs/10-cleanup.md. AWS/GCE pages upon instructions. Azure is one line
